### PR TITLE
Initial AVXMath implementation and dimension macro

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ name: Build and Test Fang
 
 on:
     push:
-        branches: [ main ]
+        branches: [ main, dev ]
     pull_request:
-        branches: [ main ]
+        branches: [ main, dev ]
 
 jobs:
     build-n-test:

--- a/src/fang/tensor/dense.c
+++ b/src/fang/tensor/dense.c
@@ -195,12 +195,12 @@ FANG_HOT FANG_INLINE static inline int _fang_ten_gemm_get_broadcast_pattern(
 
 /* Creates a new dense tensor. */
 int fang_ten_create(fang_ten_t *ten, int eid, fang_ten_dtype_t dtyp,
-    uint32_t *restrict dims, uint16_t ndims, void *restrict data)
+    fang_ten_dim_t dim, void *restrict data)
 {
     int res = FANG_OK;
 
     /* Is passed dimension valid? */
-    if(FANG_UNLIKELY(ndims == 0 || dims == NULL)) {
+    if(FANG_UNLIKELY(dim.ndims == 0 || dim.dims == NULL)) {
         res = -FANG_INVDIM;
         goto out;
     }
@@ -223,35 +223,35 @@ int fang_ten_create(fang_ten_t *ten, int eid, fang_ten_dtype_t dtyp,
         goto out;
 
     /* Validate dimensions. */
-    for(int i = 0; i < ndims; i++) {
-        if(FANG_UNLIKELY(dims[i] == 0)) {
+    for(int i = 0; i < dim.ndims; i++) {
+        if(FANG_UNLIKELY(dim.dims[i] == 0)) {
             res = -FANG_INVDIM;
             goto out;
         }
     }
     /* Store dimensions. */
-    ten->ndims = ndims;
-    ten->dims = FANG_CREATE(env->realloc, *ten->dims, ndims);
+    ten->ndims = dim.ndims;
+    ten->dims = FANG_CREATE(env->realloc, *ten->dims, dim.ndims);
     if(ten->dims == NULL) {
         res = -FANG_NOMEM;
         goto out;
     }
-    memmove(ten->dims, dims, ndims * sizeof(*ten->dims));
+    memmove(ten->dims, dim.dims, dim.ndims * sizeof(*ten->dims));
 
     /* Calculate and store strides. */
-    ten->strides = FANG_CREATE(env->realloc, *ten->strides, ndims);
+    ten->strides = FANG_CREATE(env->realloc, *ten->strides, dim.ndims);
     if(ten->strides == NULL) {
         res = -FANG_NOMEM;
         goto out;
     }
-    _fang_ten_calc_strides(ten->strides, dims, ndims);
+    _fang_ten_calc_strides(ten->strides, dim.dims, dim.ndims);
 
     /* Call operator. */
     fang_ten_ops_arg_t arg = {
         .dest = (fang_gen_t *) ten,
 
         /* Number of elements. */
-        .x = FANG_U2G((fang_uint_t) ten->strides[0] * dims[0]),
+        .x = FANG_U2G((fang_uint_t) ten->strides[0] * dim.dims[0]),
         .y = (fang_gen_t) data,
         .z = (fang_gen_t) env
     };

--- a/src/fang/util/buffer.c
+++ b/src/fang/util/buffer.c
@@ -5,13 +5,13 @@
 /* ================ PRIVATE MACROS ================ */
 
 /* Responsible for exponential growth of capacity (by twice). */
-#define _FANG_GROW_CAPACITY(x)    x < FANG_BUFFER_INIT_CAPACITY ?    \
-    FANG_BUFFER_INIT_CAPACITY : x * 2
+#define _FANG_GROW_CAPACITY(x)    ((x) < FANG_BUFFER_INIT_CAPACITY ?    \
+    FANG_BUFFER_INIT_CAPACITY : (x) * 2)
 
-#define _FANG_REPORT(buff, result)      \
-    if(FANG_UNLIKELY(buff == NULL)) {   \
-        result = -FANG_NOMEM;           \
-        goto out;                       \
+#define _FANG_REPORT(buff, result)                                      \
+    if(FANG_UNLIKELY(buff == NULL)) {                                   \
+        result = -FANG_NOMEM;                                           \
+        goto out;                                                       \
     }
 
 /* ================ PRIVATE MACROS END ================ */

--- a/src/include/env/cpu/avxmath.h
+++ b/src/include/env/cpu/avxmath.h
@@ -1,0 +1,146 @@
+#ifndef FANG_CPU_AVXMATH_H
+#define FANG_CPU_AVXMATH_H
+
+#include <compiler.h>
+
+#if defined(FANG_USE_AVX512) || defined(FANG_USE_AVX2)
+#include <immintrin.h>
+#endif  // FANG_USE_AVX512 or FANG_USE_AVX2
+
+/* ================ CONSTANT MACROS ================ */
+
+/* ======== EULER'S CONSTANT EXPONENTIAL ======== */
+
+/* Maximum and minimum values `_fang_expf256` can handle before converging
+   to inifinity and zero respectively. It is advisable to not to use such
+   large/small values. */
+#define _expf32_hi        88.3762626647949f
+#define _expf32_lo       -88.3762626647949f
+
+/* Value of `ln2` and `log2(e)`, where `ln` denotes natural log. */
+#define _expf32_ln2       0.693147180559945f
+#define _expf32_log2e     1.44269504088896341f
+
+/* Maclurin series expansion constants, upto 7 terms. */
+#define _expf32_c0        0.001388888888888f
+#define _expf32_c1        0.008333333333333f
+#define _expf32_c2        0.041666666666666f
+#define _expf32_c3        0.166666666666666f
+#define _expf32_c4        0.500000000000000f
+
+/* ======== EULER'S CONSTANT EXPONENTIAL END ======== */
+
+/* ================ CONSTANTS MACROS END ================ */
+
+
+/* ================ INLINE DEFINITIONS ================ */
+
+#ifdef FANG_USE_AVX2
+
+/* Calculates the natural exponent of a AVX2 256-bit float32 vector. */
+FANG_HOT FANG_INLINE static inline __m256 _fang_expf32_ps256(__m256 x) {
+    /* Values of `x` cannot be larger or smaller than `_expf256_hi` or
+       `_expf256_lo` respectively. */
+    x = _mm256_max_ps(x, _mm256_set1_ps(_expf32_lo));
+    x = _mm256_min_ps(x, _mm256_set1_ps(_expf32_hi));
+
+    /* Here, Maclurin's series can be directly applied to calculate the natural
+       exponent. But, in this case if the value of `x` is large, there is a big
+       hit in the accuracy, thanks to 32-bit float's limited mantissa. */
+    /* Hence, Cody-Waite scheme is being applied here by decomposing `x` into
+       two parts (high-percision, low magnitude and low-percision,
+       high-magnitude), calculating them separately and finally merging together
+       to calculate the final value with relatively good precision and
+       magnitude. */
+
+    /* ==== MATH ====
+         => x = aln2 + b    [Decomposition based on Cody-Waite scheme]
+
+                            Where, `a` is integer and `b` is the high-precision
+                            part with negligible numeric value (magnitude).
+
+         => expf(x) = expf(aln2 + b)
+                    = expf(aln2) * expf(b)
+                    = expf(ln2^a) * expf(b)
+                    = 2^a * expf(b)
+
+       As `b` is small, calculating `expf(b)` will converge easily without large
+       series expansion while maintaining good accuracy.
+
+       Ignoring `b`, the first equation can be written as follows:
+         => x = aln2    [ `b` is negligible ]
+         => a = x / ln2
+              = x * log2(e)
+
+       `a` should be integer, so
+         => a = round(x * log2(e))
+
+       And finally,
+         => b = x - aln2
+       ==== MATH END ==== */
+
+    register __m256 a = _mm256_mul_ps(x, _mm256_set1_ps(_expf32_log2e));
+                    a = _mm256_round_ps(a, _MM_FROUND_TO_NEAREST_INT |
+                                           _MM_FROUND_NO_EXC);
+    register __m256 b = _mm256_sub_ps(x, _mm256_mul_ps(a,
+                        _mm256_set1_ps(_expf32_ln2)));
+
+    /* Maclurin's series for natural exponent is:
+         => expf(x) = 1 + x + x^2/2! + x^3/3! + x^4/4! + x^5/5! + ...
+
+       As `x` here is relatively small (which is `b` in this case), small
+       expansion of the series may converge. Hence, the equation stands:
+
+         => expf(x) = x^6/6! + x^5/5! + x^4/4! + x^3/3! + x^2/2! + x + 1
+
+       Diminishing redundant calculation of power of `x` by using Horner's
+       method:
+         => expf(x) = x * (x * (x * (x * (x * (x/6! + 1/5!) + 1/4!) + 1/3!)
+                      + 1/2!) + 1) + 1
+
+       Cleaning up the factorial mess with constants:
+         => expf(x) = x * (x * (x * (x * (x * (x * c0 + c1) + c2) + c3) + c4)
+                      + one) + one
+    */
+
+    /* Prepare constants. */
+    register __m256 c0  = _mm256_set1_ps(_expf32_c0);
+    register __m256 c1  = _mm256_set1_ps(_expf32_c1);
+    register __m256 c2  = _mm256_set1_ps(_expf32_c2);
+    register __m256 c3  = _mm256_set1_ps(_expf32_c3);
+    register __m256 c4  = _mm256_set1_ps(_expf32_c4);
+    register __m256 one = _mm256_set1_ps(1.0f);
+
+    /* Calculate expf(b). */
+    register __m256 expf_b = c0;
+    /* `x * c0 + c1` */
+    expf_b = _mm256_fmadd_ps(b, expf_b, c1);
+    /* `x * (x * c0 + c1) + c2` */
+    expf_b = _mm256_fmadd_ps(b, expf_b, c2);
+    /* `x * (x * (x * c0 + c1) + c2) + c3` */
+    expf_b = _mm256_fmadd_ps(b, expf_b, c3);
+    /* `x * (x * (x * (x * c0 + c1) + c2) + c3) + c4` */
+    expf_b = _mm256_fmadd_ps(b, expf_b, c4);
+    /* `x * (x * (x * (x * (x * c0 + c1) + c2) + c3) + c4) + one` */
+    expf_b = _mm256_fmadd_ps(b, expf_b, one);
+    /* `x * (x * (x * (x * (x * (x * c0 + c1) + c2) + c3) + c4) + one) + one` */
+    expf_b = _mm256_fmadd_ps(b, expf_b, one);
+
+    /* Calculate `2^a`. */
+    register __m256i a_i32 = _mm256_cvtps_epi32(a);
+    /* IEEE-754 floats are generally stored as binary scientific notation:
+         1.<mantissa> * 2^(<exponent> - <bias>)
+       Hence, to convert `2^a` to float, keeping `a + <bias>` in exponent
+       should suffice. */
+    a_i32 = _mm256_add_epi32(a_i32, _mm256_set1_epi32(0x7F));  // Add bias, 127
+    a_i32 = _mm256_slli_epi32(a_i32, 23);                      // Store exponent
+
+    /* Return 2^a * expf(b) */
+    return _mm256_mul_ps(_mm256_castsi256_ps(a_i32), expf_b);
+}
+
+#endif  // FANG_USE_AVX2
+
+/* ================ INLINE DEFINITIONS END ================ */
+
+#endif  // FANG_CPU_AVXMATH_H

--- a/src/include/fang/tensor.h
+++ b/src/include/fang/tensor.h
@@ -8,6 +8,19 @@
 
 /* ================ HELPER MACROS ================ */
 
+/* ======== DIMENSION HELPER MACROS ======== */
+
+/* Fill in and pass the dimension tensor. */
+#define FANG_DIM(...)    (fang_ten_dim_t) {                              \
+    .dims = (uint32_t []) { __VA_ARGS__ },                               \
+    .ndims = sizeof((uint32_t []) { __VA_ARGS__ }) / sizeof(uint32_t)    \
+}
+
+/* Alias. */
+#define $D(...)          FANG_DIM(__VA_ARGS__)
+
+/* ======== DIMENSION HELPER MACROS END ======== */
+
 /* ======== FUNCTION WRAPPER MACROS ======== */
 
 /* Print tensor to stdout. */
@@ -120,6 +133,12 @@ typedef struct fang_ten {
     } data;
 } fang_ten_t;
 
+/* Structure to pass dimension data to the Tensor. */
+typedef struct fang_ten_dim {
+    uint32_t *dims;
+    int ndims;
+} fang_ten_dim_t;
+
 /* Pass arguments to the operator functions with this structure. */
 /* NOTE: Argument structure also can be used to retrieve data from operator
  *   functions. Recommended field for that is `y`.
@@ -167,8 +186,7 @@ typedef enum fang_ten_gemm_transp {
 
 /* Creates a new dense tensor. */
 FANG_API FANG_HOT int fang_ten_create(fang_ten_t *ten, int eid,
-    fang_ten_dtype_t dtyp, uint32_t *restrict dims, uint16_t ndims,
-    void *restrict data);
+    fang_ten_dtype_t dtyp, fang_ten_dim_t dim, void *restrict data);
 
 /* Creates a scalar tensor. */
 FANG_API FANG_HOT int fang_ten_scalar(fang_ten_t *ten, int eid,

--- a/src/include/fang/tensor.h
+++ b/src/include/fang/tensor.h
@@ -154,7 +154,7 @@ typedef struct fang_ten_ops {
 } fang_ten_ops_t;
 
 /* Used to indicate whether to transpose a matrix (two trailing dimension within
- * tensor) while performing GEMM. */
+   tensor) while performing GEMM. */
 typedef enum fang_ten_gemm_transp {
     FANG_TEN_GEMM_NO_TRANSPOSE,
     FANG_TEN_GEMM_TRANSPOSE
@@ -196,7 +196,7 @@ FANG_API FANG_HOT int fang_ten_sum(fang_ten_t *dest, fang_ten_t *x,
 FANG_API FANG_HOT int fang_ten_diff(fang_ten_t *dest, fang_ten_t *x,
     fang_ten_t *y);
 
-/* Multiplies two tensor. */
+/* Element-wise multiplies two tensor. */
 FANG_API FANG_HOT int fang_ten_mul(fang_ten_t *dest, fang_ten_t *x,
     fang_ten_t *y);
 

--- a/test/unit/tensor/dense.c
+++ b/test/unit/tensor/dense.c
@@ -205,133 +205,133 @@ static int setup_arithmetic(void **state) {
 
     /* Initialize operand tensors. */
     /* (8) */
-    TENCHK(fang_ten_create(&tens->ten_8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 8 }, 1, data_int));
-    TENCHK(fang_ten_create(&tens->ten_8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 8 }, 1, data_float));
-    TENCHK(fang_ten_create(&tens->ten_8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 8 }, 1, data_float));
+    TENCHK(fang_ten_create(&tens->ten_8_int16, env, FANG_TEN_DTYPE_INT16,
+        $D(8), data_int));
+    TENCHK(fang_ten_create(&tens->ten_8_bfloat16, env, FANG_TEN_DTYPE_BFLOAT16,
+        $D(8), data_float));
+    TENCHK(fang_ten_create(&tens->ten_8_float32, env, FANG_TEN_DTYPE_FLOAT32,
+        $D(8), data_float));
 
     /* (1) */
-    TENCHK(fang_ten_create(&tens->ten_1_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 1 }, 1, data_int));
-    TENCHK(fang_ten_create(&tens->ten_1_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 1 }, 1, data_float));
-    TENCHK(fang_ten_create(&tens->ten_1_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 1 }, 1, data_float));
+    TENCHK(fang_ten_create(&tens->ten_1_int16, env, FANG_TEN_DTYPE_INT16,
+        $D(1), data_int));
+    TENCHK(fang_ten_create(&tens->ten_1_bfloat16, env, FANG_TEN_DTYPE_BFLOAT16,
+        $D(1), data_float));
+    TENCHK(fang_ten_create(&tens->ten_1_float32, env, FANG_TEN_DTYPE_FLOAT32,
+        $D(1), data_float));
 
     /* (1, 1, 1, 1) */
     TENCHK(fang_ten_create(&tens->ten_1x1x1x1_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 1, 1, 1, 1 }, 4, data_int));
+        FANG_TEN_DTYPE_INT16, $D(1, 1, 1, 1), data_int));
     TENCHK(fang_ten_create(&tens->ten_1x1x1x1_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 1, 1, 1, 1 }, 4, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(1, 1, 1, 1), data_float));
     TENCHK(fang_ten_create(&tens->ten_1x1x1x1_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 1, 1, 1, 1 }, 4, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(1, 1, 1, 1), data_float));
 
     /* (8, 8) */
     TENCHK(fang_ten_create(&tens->ten_8x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 8, 8 }, 2, data_int));
+        FANG_TEN_DTYPE_INT16, $D(8, 8), data_int));
     TENCHK(fang_ten_create(&tens->ten_8x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 8, 8 }, 2, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(8, 8), data_float));
     TENCHK(fang_ten_create(&tens->ten_8x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 8, 8 }, 2, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(8, 8), data_float));
 
     /* (8, 1) */
     TENCHK(fang_ten_create(&tens->ten_8x1_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 8, 1 }, 2, data_int));
+        FANG_TEN_DTYPE_INT16, $D(8, 1), data_int));
     TENCHK(fang_ten_create(&tens->ten_8x1_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 8, 1 }, 2, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(8, 1), data_float));
     TENCHK(fang_ten_create(&tens->ten_8x1_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 8, 1 }, 2, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(8, 1), data_float));
 
     /* (3, 8, 8) */
     TENCHK(fang_ten_create(&tens->ten_3x8x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 3, 8, 8 }, 3, data_int));
+        FANG_TEN_DTYPE_INT16, $D(3, 8, 8), data_int));
     TENCHK(fang_ten_create(&tens->ten_3x8x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 3, 8, 8 }, 3, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(3, 8, 8), data_float));
     TENCHK(fang_ten_create(&tens->ten_3x8x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 3, 8, 8 }, 3, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(3, 8, 8), data_float));
 
     /* (2, 4, 8) */
     TENCHK(fang_ten_create(&tens->ten_2x4x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 2, 4, 8 }, 3, data_int));
+        FANG_TEN_DTYPE_INT16, $D(2, 4, 8), data_int));
     TENCHK(fang_ten_create(&tens->ten_2x4x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 2, 4, 8 }, 3, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(2, 4, 8), data_float));
     TENCHK(fang_ten_create(&tens->ten_2x4x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 2, 4, 8 }, 3, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(2, 4, 8), data_float));
 
     /* (1, 4, 1) */
     TENCHK(fang_ten_create(&tens->ten_1x4x1_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 1, 4, 1 }, 3, data_int));
+        FANG_TEN_DTYPE_INT16, $D(1, 4, 1), data_int));
     TENCHK(fang_ten_create(&tens->ten_1x4x1_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 1, 4, 1 }, 3, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(1, 4, 1), data_float));
     TENCHK(fang_ten_create(&tens->ten_1x4x1_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 1, 4, 1 }, 3, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(1, 4, 1), data_float));
 
     /* (2, 3, 4, 8) */
     TENCHK(fang_ten_create(&tens->ten_2x3x4x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 2, 3, 4, 8 }, 4, data_int));
+        FANG_TEN_DTYPE_INT16, $D(2, 3, 4, 8), data_int));
     TENCHK(fang_ten_create(&tens->ten_2x3x4x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 2, 3, 4, 8 }, 4, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(2, 3, 4, 8), data_float));
     TENCHK(fang_ten_create(&tens->ten_2x3x4x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 2, 3, 4, 8 }, 4, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(2, 3, 4, 8), data_float));
 
     /* (1, 3, 4, 8) */
     TENCHK(fang_ten_create(&tens->ten_1x3x4x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 1, 3, 4, 8 }, 4, data_int));
+        FANG_TEN_DTYPE_INT16, $D(1, 3, 4, 8), data_int));
     TENCHK(fang_ten_create(&tens->ten_1x3x4x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 1, 3, 4, 8 }, 4, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(1, 3, 4, 8), data_float));
     TENCHK(fang_ten_create(&tens->ten_1x3x4x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 1, 3, 4, 8 }, 4, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(1, 3, 4, 8), data_float));
 
     /* (1, 3, 1, 8) */
     TENCHK(fang_ten_create(&tens->ten_1x3x1x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 1, 3, 1, 8 }, 4, data_int));
+        FANG_TEN_DTYPE_INT16, $D(1, 3, 1, 8), data_int));
     TENCHK(fang_ten_create(&tens->ten_1x3x1x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 1, 3, 1, 8 }, 4, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(1, 3, 1, 8), data_float));
     TENCHK(fang_ten_create(&tens->ten_1x3x1x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 1, 3, 1, 8 }, 4, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(1, 3, 1, 8), data_float));
 
     /* (2, 1, 4, 8) */
     TENCHK(fang_ten_create(&tens->ten_2x1x4x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 2, 1, 4, 8 }, 4, data_int));
+        FANG_TEN_DTYPE_INT16, $D(2, 1, 4, 8), data_int));
     TENCHK(fang_ten_create(&tens->ten_2x1x4x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 2, 1, 4, 8 }, 4, data_float));
+        FANG_TEN_DTYPE_BFLOAT16, $D(2, 1, 4, 8), data_float));
     TENCHK(fang_ten_create(&tens->ten_2x1x4x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 2, 1, 4, 8 }, 4, data_float));
+        FANG_TEN_DTYPE_FLOAT32, $D(2, 1, 4, 8), data_float));
 
     /* (3, 1, 1, 2, 1) */
     TENCHK(fang_ten_create(&tens->ten_3x1x1x2x1_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 3, 1, 1, 2, 1 }, 5,
+        FANG_TEN_DTYPE_INT16, $D(3, 1, 1, 2, 1),
         data_int));
     TENCHK(fang_ten_create(&tens->ten_3x1x1x2x1_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 3, 1, 1, 2, 1 }, 5,
+        FANG_TEN_DTYPE_BFLOAT16, $D(3, 1, 1, 2, 1),
         data_float));
     TENCHK(fang_ten_create(&tens->ten_3x1x1x2x1_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 3, 1, 1, 2, 1 }, 5,
+        FANG_TEN_DTYPE_FLOAT32, $D(3, 1, 1, 2, 1),
         data_float));
 
     /* (1, 2, 3, 2, 5) */
     TENCHK(fang_ten_create(&tens->ten_1x2x3x2x5_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 1, 2, 3, 2, 5 }, 5,
+        FANG_TEN_DTYPE_INT16, $D(1, 2, 3, 2, 5),
         data_int));
     TENCHK(fang_ten_create(&tens->ten_1x2x3x2x5_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 1, 2, 3, 2, 5 }, 5,
+        FANG_TEN_DTYPE_BFLOAT16, $D(1, 2, 3, 2, 5),
         data_float));
     TENCHK(fang_ten_create(&tens->ten_1x2x3x2x5_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 1, 2, 3, 2, 5 }, 5,
+        FANG_TEN_DTYPE_FLOAT32, $D(1, 2, 3, 2, 5),
         data_float));
 
     /* Resulting tensors. */
     /* (8) */
     TENCHK(fang_ten_create(&tens->res_8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 8 }, 1,
+        FANG_TEN_DTYPE_INT16, $D(8),
         data_int));
     TENCHK(fang_ten_create(&tens->res_8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 8 }, 1,
+        FANG_TEN_DTYPE_BFLOAT16, $D(8),
         data_float));
     TENCHK(fang_ten_create(&tens->res_8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 8 }, 1,
+        FANG_TEN_DTYPE_FLOAT32, $D(8),
         data_float));
 
     /* () */
@@ -344,68 +344,68 @@ static int setup_arithmetic(void **state) {
 
     /* (8, 8) */
     TENCHK(fang_ten_create(&tens->res_8x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 8, 8 }, 2,
+        FANG_TEN_DTYPE_INT16, $D(8, 8),
         data_int));
     TENCHK(fang_ten_create(&tens->res_8x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 8, 8 }, 2,
+        FANG_TEN_DTYPE_BFLOAT16, $D(8, 8),
         data_float));
     TENCHK(fang_ten_create(&tens->res_8x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 8, 8 }, 2,
+        FANG_TEN_DTYPE_FLOAT32, $D(8, 8),
         data_float));
 
     /* (1, 1, 1, 8) */
     TENCHK(fang_ten_create(&tens->res_1x1x1x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 1, 1, 1, 8 }, 4,
+        FANG_TEN_DTYPE_INT16, $D(1, 1, 1, 8),
         data_int));
     TENCHK(fang_ten_create(&tens->res_1x1x1x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 1, 1, 1, 8 }, 4,
+        FANG_TEN_DTYPE_BFLOAT16, $D(1, 1, 1, 8),
         data_float));
     TENCHK(fang_ten_create(&tens->res_1x1x1x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 1, 1, 1, 8 }, 4,
+        FANG_TEN_DTYPE_FLOAT32, $D(1, 1, 1, 8),
         data_float));
 
     /* (3, 8, 8) */
     TENCHK(fang_ten_create(&tens->res_3x8x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 3, 8, 8 }, 3,
+        FANG_TEN_DTYPE_INT16, $D(3, 8, 8),
         data_int));
     TENCHK(fang_ten_create(&tens->res_3x8x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 3, 8, 8 }, 3,
+        FANG_TEN_DTYPE_BFLOAT16, $D(3, 8, 8),
         data_float));
     TENCHK(fang_ten_create(&tens->res_3x8x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 3, 8, 8 }, 3,
+        FANG_TEN_DTYPE_FLOAT32, $D(3, 8, 8),
         data_float));
 
     /* (2, 4, 8) */
     TENCHK(fang_ten_create(&tens->res_2x4x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 2, 4, 8 }, 3,
+        FANG_TEN_DTYPE_INT16, $D(2, 4, 8),
         data_int));
     TENCHK(fang_ten_create(&tens->res_2x4x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 2, 4, 8 }, 3,
+        FANG_TEN_DTYPE_BFLOAT16, $D(2, 4, 8),
         data_float));
     TENCHK(fang_ten_create(&tens->res_2x4x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 2, 4, 8 }, 3,
+        FANG_TEN_DTYPE_FLOAT32, $D(2, 4, 8),
         data_float));
 
     /* (2, 3, 4, 8) */
     TENCHK(fang_ten_create(&tens->res_2x3x4x8_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 2, 3, 4, 8 }, 4,
+        FANG_TEN_DTYPE_INT16, $D(2, 3, 4, 8),
         data_int));
     TENCHK(fang_ten_create(&tens->res_2x3x4x8_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 2, 3, 4, 8 }, 4,
+        FANG_TEN_DTYPE_BFLOAT16, $D(2, 3, 4, 8),
         data_float));
     TENCHK(fang_ten_create(&tens->res_2x3x4x8_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 2, 3, 4, 8 }, 4,
+        FANG_TEN_DTYPE_FLOAT32, $D(2, 3, 4, 8),
         data_float));
 
     /* (3, 2, 3, 2, 5) */
     TENCHK(fang_ten_create(&tens->res_3x2x3x2x5_int16, env,
-        FANG_TEN_DTYPE_INT16, (uint32_t[]) { 3, 2, 3, 2, 5 }, 5,
+        FANG_TEN_DTYPE_INT16, $D(3, 2, 3, 2, 5),
         data_int));
     TENCHK(fang_ten_create(&tens->res_3x2x3x2x5_bfloat16, env,
-        FANG_TEN_DTYPE_BFLOAT16, (uint32_t[]) { 3, 2, 3, 2, 5 }, 5,
+        FANG_TEN_DTYPE_BFLOAT16, $D(3, 2, 3, 2, 5),
         data_float));
     TENCHK(fang_ten_create(&tens->res_3x2x3x2x5_float32, env,
-        FANG_TEN_DTYPE_FLOAT32, (uint32_t[]) { 3, 2, 3, 2, 5 }, 5,
+        FANG_TEN_DTYPE_FLOAT32, $D(3, 2, 3, 2, 5),
         data_float));
 
     *state = (void *) tens;
@@ -438,24 +438,23 @@ static void fang_ten_create_test(void **state) {
     /* Get the Environment. */
     int env = (int) (uint64_t) *state;
 
-    uint32_t dims[] = { 3, 4, 7, 2, 8, 5 };
+    fang_ten_dim_t dim = FANG_DIM(3, 4, 7, 2, 8, 5);
     fang_ten_t ten;
 
     /* Tensor creation should be successful. */
-    TENCHK(fang_ten_create(&ten, env, FANG_TEN_DTYPE_FLOAT16, dims,
-        _ARR_SIZ(dims), NULL));
+    TENCHK(fang_ten_create(&ten, env, FANG_TEN_DTYPE_FLOAT16, dim, NULL));
 
     /* Environment ID should match. */
     assert_int_equal(ten.eid, env);
 
     /* Dimension count should match. */
-    assert_int_equal(ten.ndims, _ARR_SIZ(dims));
+    assert_int_equal(ten.ndims, dim.ndims);
 
     /* Dimension and strides check. */
     uint32_t stride = 1;
     for(int i = 0; i < ten.ndims; i++) {
         /* Dimension should match. */
-        assert_int_equal(ten.dims[i], dims[i]);
+        assert_int_equal(ten.dims[i], dim.dims[i]);
 
         /* Stride should match. */
         assert_int_equal(ten.strides[ten.ndims - (i + 1)], stride);
@@ -484,8 +483,7 @@ static void fang_ten_create_test(void **state) {
     fang_ten_release(&ten);
 
     /* Create a new tensor with data. */
-    TENCHK(fang_ten_create(&ten, env, FANG_TEN_DTYPE_INT8, dims,
-        _ARR_SIZ(dims), input_data));
+    TENCHK(fang_ten_create(&ten, env, FANG_TEN_DTYPE_INT8, dim, input_data));
 
     /* Check data initialization. */
     int8_t *idata = ten.data.dense;
@@ -516,8 +514,7 @@ static void fang_ten_scale_test(void **state) {
     }
 
     fang_ten_t ten;
-    TENCHK(fang_ten_create(&ten, env, FANG_TEN_DTYPE_INT8,
-        (uint32_t []) { 4, 4 }, 2, data_int));
+    TENCHK(fang_ten_create(&ten, env, FANG_TEN_DTYPE_INT8, $D(4, 4), data_int));
     int siz = (int) (ten.strides[0] * ten.dims[0]);
 
     /* Scale by 3. */
@@ -531,8 +528,8 @@ static void fang_ten_scale_test(void **state) {
     fang_ten_release(&ten);
 
     /* Create another tensor with different datatype this time. */
-    TENCHK(fang_ten_create(&ten, env, FANG_TEN_DTYPE_FLOAT16,
-        (uint32_t []) { 4, 4, 13 }, 3, data_float));
+    TENCHK(fang_ten_create(&ten, env, FANG_TEN_DTYPE_FLOAT16, $D(4, 4, 13),
+        data_float));
     siz = (int) (ten.strides[0] * ten.dims[0]);
 
     /* Scale by 2. */
@@ -556,9 +553,9 @@ static void fang_ten_fill_test(void **state) {
     fang_ten_t ten2;
 
     TENCHK(fang_ten_create(&ten1, env, FANG_TEN_DTYPE_INT8,
-        (uint32_t []) { 4, 4 }, 2, NULL));
+        $D(4, 4), NULL));
     TENCHK(fang_ten_create(&ten2, env, FANG_TEN_DTYPE_BFLOAT16,
-        (uint32_t []) { 4, 4 }, 2, NULL));
+        $D(4, 4), NULL));
 
     /* Fill the tensors. */
     fang_ten_fill(&ten1, FANG_I2G(69));
@@ -1346,70 +1343,70 @@ static void fang_ten_gemm_test(void **state) {
 
     /* Create operand tensors. */
     TENCHK(fang_ten_create(&ten_2x2_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 2, 2 }, 2, data));
+        $D(2, 2), data));
     TENCHK(fang_ten_create(&ten_13x17_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 13, 17 }, 2, data));
+        $D(13, 17), data));
     TENCHK(fang_ten_create(&ten_17x31_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 17, 31 }, 2, data));
+        $D(17, 31), data));
     TENCHK(fang_ten_create(&ten_64x64_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 64, 64 }, 2, data));
+        $D(64, 64), data));
     TENCHK(fang_ten_create(&ten_4x4x5_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 4, 4, 5 }, 3, data));
+        $D(4, 4, 5), data));
     TENCHK(fang_ten_create(&ten_5x3_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 3 }, 2, data));
+        $D(5, 3), data));
     TENCHK(fang_ten_create(&ten_5x5x7_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 5, 7 }, 3, data));
+        $D(5, 5, 7), data));
     TENCHK(fang_ten_create(&ten_5x7x5_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 7, 5 }, 3, data));
+        $D(5, 7, 5), data));
     TENCHK(fang_ten_create(&ten_7x5x7x6_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 7, 5, 7, 6 }, 4, data));
+        $D(7, 5, 7, 6), data));
     TENCHK(fang_ten_create(&ten_5x6x7_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 6, 7 }, 3, data));
+        $D(5, 6, 7), data));
     TENCHK(fang_ten_create(&ten_3x4x2x3_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 3, 4, 2, 3 }, 4, data));
+        $D(3, 4, 2, 3), data));
     TENCHK(fang_ten_create(&ten_3x1x3x2_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 3, 1, 3, 2 }, 4, data));
+        $D(3, 1, 3, 2), data));
     TENCHK(fang_ten_create(&ten_3x5x4x3x3_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 3, 5, 4, 3, 3 }, 5, data));
+        $D(3, 5, 4, 3, 3), data));
     TENCHK(fang_ten_create(&ten_5x4x3x3_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 4, 3, 3 }, 4, data));
+        $D(5, 4, 3, 3), data));
     TENCHK(fang_ten_create(&ten_4x4_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 4, 4 }, 2, data));
+        $D(4, 4), data));
     TENCHK(fang_ten_create(&ten_4x1_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 4, 1 }, 2, data));
+        $D(4, 1), data));
     TENCHK(fang_ten_create(&ten_4x2_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 4, 2 }, 2, data));
+        $D(4, 2), data));
     TENCHK(fang_ten_create(&ten_1x4_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 1, 4 }, 2, data));
+        $D(1, 4), data));
     TENCHK(fang_ten_create(&ten_2x4_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 2, 4 }, 2, data));
+        $D(2, 4), data));
 
     TENCHK(fang_ten_create(&res_2x2_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 2, 2 }, 2, NULL));
+        $D(2, 2), NULL));
     TENCHK(fang_ten_create(&res_13x31_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 13, 31 }, 2, NULL));
+        $D(13, 31), NULL));
     TENCHK(fang_ten_create(&res_64x64_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 64, 64 }, 2, data));
+        $D(64, 64), data));
     TENCHK(fang_ten_create(&res_4x4x3_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 4, 4, 3 }, 3, NULL));
+        $D(4, 4, 3), NULL));
     TENCHK(fang_ten_create(&res_5x5x5_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 5, 5 }, 3, NULL));
+        $D(5, 5, 5), NULL));
     TENCHK(fang_ten_create(&res_7x5x7x7_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 7, 5, 7, 7 }, 4, NULL));
+        $D(7, 5, 7, 7), NULL));
     TENCHK(fang_ten_create(&res_3x4x2x2_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 3, 4, 2, 2 }, 4, NULL));
+        $D(3, 4, 2, 2), NULL));
     TENCHK(fang_ten_create(&res_3x5x4x3x3_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 3, 5, 4, 3, 3 }, 5, NULL));
+        $D(3, 5, 4, 3, 3), NULL));
     TENCHK(fang_ten_create(&res_4x1_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 4, 1 }, 2, data));
+        $D(4, 1), data));
     TENCHK(fang_ten_create(&res_4x2_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 4, 2 }, 2, NULL));
+        $D(4, 2), NULL));
     TENCHK(fang_ten_create(&res_1x4_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 1, 4 }, 2, NULL));
+        $D(1, 4), NULL));
     TENCHK(fang_ten_create(&res_2x4_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 2, 4 }, 2, data));
+        $D(2, 4), data));
     TENCHK(fang_ten_create(&res_4x4_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 4, 4 }, 2, data));
+        $D(4, 4), data));
 
     /* Dimensions should be incompatible. */
     assert_int_equal(fang_ten_matmul(&res_4x4_float32, &ten_4x2_float32,
@@ -1511,24 +1508,24 @@ static void fang_ten_gemm_test(void **state) {
     fang_ten_t res_5x5_float32;
 
     TENCHK(fang_ten_create(&ten_7x5_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 7, 5 }, 2, data));
+        $D(7, 5), data));
     TENCHK(fang_ten_create(&ten_7x3_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 7, 3 }, 2, data));
+        $D(7, 3), data));
     TENCHK(fang_ten_create(&ten_13x7_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 13, 7 }, 2, data));
+        $D(13, 7), data));
     TENCHK(fang_ten_create(&ten_5x7_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 7 }, 2, data));
+        $D(5, 7), data));
     TENCHK(fang_ten_create(&ten_6x5_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 6, 5 }, 2, data));
+        $D(6, 5), data));
     TENCHK(fang_ten_create(&ten_5x6_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 6 }, 2, data));
+        $D(5, 6), data));
 
     TENCHK(fang_ten_create(&res_5x3_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 3 }, 2, NULL));
+        $D(5, 3), NULL));
     TENCHK(fang_ten_create(&res_13x5_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 13, 5 }, 2, NULL));
+        $D(13, 5), NULL));
     TENCHK(fang_ten_create(&res_5x5_float32, env, FANG_TEN_DTYPE_FLOAT32,
-        (uint32_t []) { 5, 5 }, 2, NULL));
+        $D(5, 5), NULL));
 
     /* (7, 5) ^ T @ (7, 3) */
     TENCHK(fang_ten_gemm(FANG_TEN_GEMM_TRANSPOSE, FANG_TEN_GEMM_NO_TRANSPOSE,


### PR DESCRIPTION
This PR: 
 - Provides initial implementation of AVX2 math functions (starting with expf32)
 - Introduce macro to pass dimension data to Tesnor instead of passing arrays.

Resolves #8